### PR TITLE
Added `global` option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,9 +5,11 @@
 [![Dependency status][david-img]][david-url]
 
 ### koa-no-cache
-no cache for some paths or types
+no cache for koa apps
 
 ### example
+
+#### Adding no cache header on some paths or types
 
 ```js
 var noCache = require('koa-no-cache'),
@@ -22,6 +24,19 @@ app.use(noCache({
 
 * [paths](https://github.com/pillarjs/path-to-regexp)
 * [types](https://github.com/jshttp/type-is)
+
+
+#### Adding no cache header globally
+
+```js
+var noCache = require('koa-no-cache'),
+  koa = require('koa'),
+  app = koa();
+
+app.use(noCache({
+  global: true
+}));
+```
 
 ### License
 MIT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-no-cache",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "no cache for some paths or types",
   "main": "index.js",
   "directories": {

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,8 @@ var serve = require('koa-static-cache'),
   equal = assert.deepEqual,
   noCache = require('..'),
   koa = require('koa'),
-  app = koa();
+  app = koa(),
+  globalNoCahceApp = koa();
 
 describe('# koa-no-cache', function() {
   app.use(noCache({
@@ -15,6 +16,14 @@ describe('# koa-no-cache', function() {
   }));
   app.use(serve('test'));
   app.use(function * () {
+    this.body = 'test';
+  });
+
+  globalNoCahceApp.use(noCache({
+    global: true
+  }));
+  globalNoCahceApp.use(serve('test'));
+  globalNoCahceApp.use(function * () {
     this.body = 'test';
   });
 
@@ -67,6 +76,28 @@ describe('# koa-no-cache', function() {
         .end(function(err, res) {
           assertError(err);
           assertRes(res, false);
+          done();
+        });
+    });
+  });
+
+  describe('global', function() {
+    it('manifest', function(done) {
+      request(globalNoCahceApp.listen())
+        .get('/cache.manifest')
+        .end(function(err, res) {
+          assertError(err);
+          assertRes(res, true);
+          done();
+        });
+    });
+
+    it('javascript', function(done) {
+      request(globalNoCahceApp.listen())
+        .get('/index.js')
+        .end(function(err, res) {
+          assertError(err);
+          assertRes(res, true);
           done();
         });
     });


### PR DESCRIPTION
Hey mate,

Great simple middleware. I was about to write my own but quickly searched for `koa-no-cache` on NPM and seems you already did my job for me :)

I had a use case where I needed to add this globally across an API so thought I would add a global option that doesn't do any of the checks and simply adds the headers.

Thought it might also be handy for others.
